### PR TITLE
update cloudflare bypass and default content rating enum

### DIFF
--- a/src/generic/config.ts
+++ b/src/generic/config.ts
@@ -3,7 +3,7 @@
 
 import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/types";
 
-const BASE_VERSION = "1.0.0-alpha.3";
+const BASE_VERSION = "1.0.0-alpha.4";
 
 export const basePbConfig = {
   name: "",

--- a/src/generic/config.ts
+++ b/src/generic/config.ts
@@ -11,12 +11,13 @@ export const basePbConfig = {
   version: BASE_VERSION,
   icon: "icon.png",
   language: "en",
-  contentRating: "EVERYONE" as ContentRating,
+  contentRating: ContentRating.EVERYONE as ContentRating,
   capabilities: [
     SourceIntents.CHAPTER_PROVIDING,
     SourceIntents.DISCOVER_SECIONS_PROVIDING,
     SourceIntents.SEARCH_RESULTS_PROVIDING,
     SourceIntents.SETTINGS_FORM_PROVIDING,
+    SourceIntents.CLOUDFLARE_BYPASS_PROVIDING,
   ],
   badges: [],
   developers: [

--- a/src/generic/main.ts
+++ b/src/generic/main.ts
@@ -7,7 +7,6 @@ import {
   type ChapterDetails,
   type ChapterProviding,
   type CloudflareBypassRequestProviding,
-  CloudflareError,
   ContentRating,
   type Cookie,
   CookieStorageInterceptor,
@@ -21,7 +20,6 @@ import {
   type PagedResults,
   PaperbackInterceptor,
   type Request,
-  type Response,
   type SearchFilter,
   type SearchQuery,
   type SearchResultItem,
@@ -62,7 +60,14 @@ export abstract class MangaStreamGeneric
 
   parser: MangaStreamParser = new MangaStreamParser();
 
-  requestManager: PaperbackInterceptor | undefined;
+  private _requestManager?: PaperbackInterceptor;
+
+  get requestManager(): PaperbackInterceptor {
+    if (!this._requestManager) {
+      this._requestManager = new MangaStreamInterceptor("main", this.domain);
+    }
+    return this._requestManager;
+  }
 
   language = "🇬🇧";
 
@@ -127,7 +132,6 @@ export abstract class MangaStreamGeneric
   ];
 
   constructor() {
-    this.setup();
     this.configureSections();
   }
 
@@ -153,10 +157,6 @@ export abstract class MangaStreamGeneric
       console.log(e);
     }
     return filters;
-  }
-
-  setup() {
-    this.requestManager = new MangaStreamInterceptor("main", this.domain);
   }
 
   globalRateLimiter = new BasicRateLimiter("ratelimiter", {
@@ -185,8 +185,7 @@ export abstract class MangaStreamGeneric
       method: "GET",
     };
 
-    const [response, buffer] = await Application.scheduleRequest(request);
-    this.checkResponseError(request, response);
+    const [_response, buffer] = await Application.scheduleRequest(request);
     const $ = cheerio.load(Application.arrayBufferToUTF8String(buffer));
     tags = this.parser.parseTags($);
     Application.setState(tags, "tags");
@@ -227,8 +226,7 @@ export abstract class MangaStreamGeneric
       url: urlBuilder.build(),
       method: "GET",
     };
-    const [response, buffer] = await Application.scheduleRequest(request);
-    this.checkResponseError(request, response);
+    const [_response, buffer] = await Application.scheduleRequest(request);
     const $ = cheerio.load(Application.arrayBufferToUTF8String(buffer));
     const results = this.parser.parseSearchResults($);
 
@@ -265,8 +263,7 @@ export abstract class MangaStreamGeneric
         : `${this.domain}/${this.directoryPath}/${mangaId}/`,
       method: "GET",
     };
-    const [response, buffer] = await Application.scheduleRequest(request);
-    this.checkResponseError(request, response);
+    const [_response, buffer] = await Application.scheduleRequest(request);
     const $ = cheerio.load(Application.arrayBufferToUTF8String(buffer));
 
     return this.parser.parseMangaDetails($, mangaId, this);
@@ -280,8 +277,7 @@ export abstract class MangaStreamGeneric
     };
 
     // const response = await this.requestManager.schedule(request, 1)
-    const [response, buffer] = await Application.scheduleRequest(request);
-    this.checkResponseError(request, response);
+    const [_response, buffer] = await Application.scheduleRequest(request);
     const $ = cheerio.load(Application.arrayBufferToUTF8String(buffer));
 
     return this.parser.parseChapterList($, sourceManga, this);
@@ -295,8 +291,7 @@ export abstract class MangaStreamGeneric
       method: "GET",
     };
 
-    const [response, buffer] = await Application.scheduleRequest(request);
-    this.checkResponseError(request, response);
+    const [_, buffer] = await Application.scheduleRequest(request);
     const $ = cheerio.load(Application.arrayBufferToUTF8String(buffer));
 
     const chapters = $("div#chapterlist").find("li").toArray();
@@ -323,7 +318,6 @@ export abstract class MangaStreamGeneric
     };
 
     const [_response, _buffer] = await Application.scheduleRequest(_request);
-    this.checkResponseError(_request, _response);
     const _$ = cheerio.load(Application.arrayBufferToUTF8String(_buffer));
 
     return this.parser.parseChapterDetails(_$, chap);
@@ -351,8 +345,7 @@ export abstract class MangaStreamGeneric
       method: "GET",
     };
 
-    const [response, buffer] = await Application.scheduleRequest(request);
-    this.checkResponseError(request, response);
+    const [_response, buffer] = await Application.scheduleRequest(request);
     const $ = cheerio.load(Application.arrayBufferToUTF8String(buffer));
     let s: MangaStreamDiscoverSection;
     switch (section.id) {
@@ -385,16 +378,6 @@ export abstract class MangaStreamGeneric
         continue;
       }
       this.cookieStorageInterceptor.setCookie(cookie);
-    }
-  }
-
-  checkResponseError(request: Request, response: Response): void {
-    switch (response.status) {
-      case 403:
-      case 503:
-        throw new CloudflareError(request, "Error Code: " + response.status);
-      case 404:
-        throw new Error(`The requested page ${response.url} was not found!`);
     }
   }
 
@@ -459,7 +442,6 @@ export abstract class MangaStreamGeneric
       method: "HEAD",
     };
     const [headResponse, __] = await Application.scheduleRequest(headRequest);
-    this.checkResponseError(headRequest, headResponse);
 
     let postId: string;
 

--- a/src/generic/main.ts
+++ b/src/generic/main.ts
@@ -60,16 +60,9 @@ export abstract class MangaStreamGeneric
 
   parser: MangaStreamParser = new MangaStreamParser();
 
-  private _requestManager?: PaperbackInterceptor;
+  interceptor?: PaperbackInterceptor;
 
-  get requestManager(): PaperbackInterceptor {
-    if (!this._requestManager) {
-      this._requestManager = new MangaStreamInterceptor("main", this.domain);
-    }
-    return this._requestManager;
-  }
-
-  language = "🇬🇧";
+  language = "en";
 
   bypassPage = "";
   mangaSelectorAlternativeTitles = "Alternative Titles";
@@ -172,7 +165,8 @@ export abstract class MangaStreamGeneric
   async initialise(): Promise<void> {
     this.globalRateLimiter.registerInterceptor();
     this.cookieStorageInterceptor.registerInterceptor();
-    this.requestManager?.registerInterceptor();
+    this.interceptor = this.interceptor ?? new MangaStreamInterceptor("main", this.domain);
+    this.interceptor.registerInterceptor();
   }
 
   async getSearchTags(): Promise<TagSection[]> {

--- a/src/generic/network.ts
+++ b/src/generic/network.ts
@@ -1,7 +1,12 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 /* Copyright © 2026 Inkdex */
 
-import { PaperbackInterceptor, type Request, type Response } from "@paperback/types";
+import {
+  CloudflareError,
+  PaperbackInterceptor,
+  type Request,
+  type Response,
+} from "@paperback/types";
 
 export class MangaStreamInterceptor extends PaperbackInterceptor {
   domain: string;
@@ -29,6 +34,26 @@ export class MangaStreamInterceptor extends PaperbackInterceptor {
     response: Response,
     data: ArrayBuffer,
   ): Promise<ArrayBuffer> {
+    const cfMitigated = response.headers?.["cf-mitigated"];
+    if (cfMitigated === "challenge") {
+      throw new CloudflareError(
+        {
+          url: this.domain,
+          method: "GET",
+          headers: {
+            referer: `${this.domain}/`,
+            origin: `${this.domain}/`,
+            "user-agent": await Application.getDefaultUserAgent(),
+          },
+        },
+        "Cloudflare detected, bypass it to continue!",
+      );
+    }
+
+    if (response.status !== 200) {
+      throw new Error(`Request failed with status ${response.status}: ${request.url}`);
+    }
+
     return data;
   }
 }


### PR DESCRIPTION
- fixed interceptor timing issue by using lazy loading. now it waits for the domain to be set instead of giving "nil instead of string"
- fixed contentRating to use enum instead of string. this was causing getMangaDetails to fail for extensions that inherit the default rating (unable to convert jsvalue(EVERYONE) to content rating)
- obvious change to interceptor cloudflare detection